### PR TITLE
bootparameter: add missing gap of 6 sectors

### DIFF
--- a/meta-rz-bsp/recipes-bsp/bootparameter/bootparameter/bootparameter.c
+++ b/meta-rz-bsp/recipes-bsp/bootparameter/bootparameter/bootparameter.c
@@ -47,6 +47,11 @@ int main(int argc, char *argv[])
 		val = 0xAA;
 		fwrite(&val, 1, 1, fptr);
 
+		/* Add gap of 6 sectors (6 x 512 bytes): */
+		val = 0xFF;
+		for(i=0;i<3072; i++)
+			 fwrite(&val, 1, 1, fptr);
+
 		fclose(fptr);
 	}
 	return 0;


### PR DESCRIPTION
When writing bl2_bp.bin to the SD card, nothing happens at power on.

According to:
    https://renesas.info/w/images/2/28/SD_card.png

There must be a 6 sectors gap between the boot parameters and the start of BL2, and BL2 must start at sector 8. Currently, BL2 starts at sector 2.

Add the required gap of 6 sectors of 512 bytes each so that the boot process can work.