### PR TITLE
recipes-core: packagegroup: Add gpu and benchmarking packagegroup

### DIFF
--- a/meta-rz-bsp/dynamic-layers/meta-rz-panfrost/recipes-core/images/renesas-image-demo.bbappend
+++ b/meta-rz-bsp/dynamic-layers/meta-rz-panfrost/recipes-core/images/renesas-image-demo.bbappend
@@ -1,7 +1,0 @@
-# Copyright (c) 2024, Renesas Electronics Corp.
-#
-# SPDX-License-Identifier: MIT
-
-CORE_IMAGE_BASE_INSTALL += " \
-	startup \
-"

--- a/meta-rz-bsp/dynamic-layers/meta-rz-panfrost/recipes-core/packagegroups/packagegroup-rz-tools-gpu.bbappend
+++ b/meta-rz-bsp/dynamic-layers/meta-rz-panfrost/recipes-core/packagegroups/packagegroup-rz-tools-gpu.bbappend
@@ -1,0 +1,7 @@
+# Copyright (c) 2024, Renesas Electronics Corp.
+#
+# SPDX-License-Identifier: MIT
+
+RDEPENDS:${PN} += " \
+	startup \
+"

--- a/meta-rz-bsp/recipes-core/images/renesas-image-demo.bb
+++ b/meta-rz-bsp/recipes-core/images/renesas-image-demo.bb
@@ -10,8 +10,6 @@ LICENSE = "MIT"
 IMAGE_FEATURES += " weston"
 
 CORE_IMAGE_BASE_INSTALL += " \
-	glmark2 \
-	gtk+3-demo \
-	kmscube \
+	packagegroup-rz-tools-gpu \
 	packagegroup-rz-tools-hw \
 "

--- a/meta-rz-bsp/recipes-core/images/renesas-image-demo.bb
+++ b/meta-rz-bsp/recipes-core/images/renesas-image-demo.bb
@@ -10,6 +10,7 @@ LICENSE = "MIT"
 IMAGE_FEATURES += " weston"
 
 CORE_IMAGE_BASE_INSTALL += " \
+	packagegroup-rz-tools-benchmark \
 	packagegroup-rz-tools-gpu \
 	packagegroup-rz-tools-hw \
 "

--- a/meta-rz-bsp/recipes-core/packagegroups/packagegroup-rz-tools-benchmark.bb
+++ b/meta-rz-bsp/recipes-core/packagegroups/packagegroup-rz-tools-benchmark.bb
@@ -1,0 +1,16 @@
+# Copyright (c) 2024, Renesas Electronics Corp.
+#
+# SPDX-License-Identifier: MIT
+
+SUMMARY = "Benchmark packages packagegroup."
+DESCRIPTION = "Set of packages useful for hw benchmark"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+	bonnie++ \
+	iperf3 \
+	stress-ng \
+"

--- a/meta-rz-bsp/recipes-core/packagegroups/packagegroup-rz-tools-gpu.bb
+++ b/meta-rz-bsp/recipes-core/packagegroups/packagegroup-rz-tools-gpu.bb
@@ -1,0 +1,16 @@
+# Copyright (c) 2024, Renesas Electronics Corp.
+#
+# SPDX-License-Identifier: MIT
+
+SUMMARY = "Graphics packages packagegroup."
+DESCRIPTION = "Set of packages useful for graphics and hw acceleration"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+	glmark2 \
+	gtk+3-demo \
+	kmscube \
+"


### PR DESCRIPTION
Hi All,

Instead of adding packages into the renesas-image-demo, for scaling
maybe is better to group up those packages into "labelled" packagegroups.

This series add 2 new packagegroup:
 - packagegroup-rz-tools-gpu: graphics and hw acceleration
 - packagegroup-rz-tools-benchmark: benchmarking

Let's use those into the renesas-image-demo image.
Thanks in advance for the review :)

Regards,
Tommaso
