### PR TITLE
meta-rz-bsp: trusted-firmware-a: Fix fiptool linkage

### DIFF
--- a/meta-rz-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a-renesas_2.9.0.bb
+++ b/meta-rz-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a-renesas_2.9.0.bb
@@ -6,3 +6,14 @@ COMPATIBLE_MACHINE = "(rzg2h-family|rzg2l-family)"
 SRCREV_tfa = "cc18695622e5637ec70ee3ae8eb5e83b09d13804"
 LIC_FILES_CHKSUM += "file://docs/license.rst;md5=b2c740efedc159745b9b31f88ff03dde"
 SRC_URI = "git://github.com/renesas-rz/rzg_trusted-firmware-a.git;branch=v2.9/rz;protocol=https;name=tfa"
+
+# In TF-A v2.10.0, the variable containing linker arguments in the fiptool
+# Makefile was changed from `LDLIBS` to `LDOPTS`.
+#
+# When building with the Yocto scarthgap branch, the trusted-firmware-a.inc
+# file in meta-arm handles modification of the LDOPTS variable for TF-A 2.10.0
+# or later. So to fix the build with Scarthgap and TF-A 2.9.0 we need to modify
+# the LDLIBS variable ourselves.
+do_compile:prepend() {
+	sed -i '/^LDLIBS/ s,$, \$\{BUILD_LDFLAGS},' ${S}/tools/fiptool/Makefile
+}

--- a/meta-rz-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.8.bb
+++ b/meta-rz-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.8.bb
@@ -13,3 +13,14 @@ SRC_URI = "git://git.trustedfirmware.org/TF-A/trusted-firmware-a.git;protocol=ht
 SRC_URI:remove = "file://ssl.patch"
 
 LIC_FILES_CHKSUM += "file://docs/license.rst;md5=b2c740efedc159745b9b31f88ff03dde"
+
+# In TF-A v2.10.0, the variable containing linker arguments in the fiptool
+# Makefile was changed from `LDLIBS` to `LDOPTS`.
+#
+# When building with the Yocto kirkstone branch, the trusted-firmware-a.inc
+# file in meta-arm handles modification of the LDLIBS variable for TF-A 2.9.0
+# or earlier. So to fix the build with Kirkstone and TF-A 2.10.8 we need to
+# modify the LDOPTS variable ourselves.
+do_compile:prepend() {
+	sed -i '/^LDOPTS/ s,$, \$\{BUILD_LDFLAGS},' ${S}/tools/fiptool/Makefile
+}


### PR DESCRIPTION
In recipes-bsp/trusted-firmware-a/trusted-firmware-a.inc in meta-arm, the LDOPTS variable in the fiptool Makefile is modified to pass the correct arguments to the linker. However, we're building v2.9.0 where the variable LDLIBS is used instead, so we need to modify this ourselves.

Prior to this patch, in the TF-A working directory:

    $ ldd git/tools/fiptool/fiptool
        linux-vdso.so.1 (0x00007fff8b0b7000)
        libcrypto.so.3 => not found
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7cd9617000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f7cd981f000)

After this patch, with paths shortened for clarity:

    $ ldd git/tools/fiptool/fiptool
        linux-vdso.so.1 (0x00007ffd705e8000)
        libcrypto.so.3 => [...]/tmp/work/smarc_rzv2l-poky-linux/trusted-firmware-a-renesas/2.9.0/recipe-sysroot-native/usr/lib/libcrypto.so.3 (0x00007f7d22000000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f7d22615000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7d21e0e000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f7d2260f000)
        [...]/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007f7d2264e000)

Fixes #7.